### PR TITLE
Fix memory leak on FreeBSD

### DIFF
--- a/src/freebsd.rs
+++ b/src/freebsd.rs
@@ -9,5 +9,10 @@ extern "C" {
 pub(crate) fn num_threads() -> Option<NonZeroUsize> {
     // Safety: `kinfo_getproc` and `getpid` are both thread-safe. All invariants of `as_ref` are
     // upheld.
-    NonZeroUsize::new(unsafe { kinfo_getproc(libc::getpid()).as_ref() }?.ki_numthreads as usize)
+    unsafe {
+        let kip = kinfo_getproc(libc::getpid());
+        let num_threads = NonZeroUsize::new(kip.as_ref()?.ki_numthreads as usize);
+        libc::free(kip as *mut libc::c_void);
+        num_threads
+    }
 }


### PR DESCRIPTION
As per kinfo_getproc(3) "*The pointer was obtained by an internal call to malloc(3) and must be freed by the caller with a call to free(3).*"