### PR TITLE
Implement MacOS

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -36,8 +36,8 @@ jobs:
           #  triple: x86_64-pc-windows-gnu
           - name: Linux
             triple: x86_64-unknown-linux-gnu
-          # - name: macOS
-          #   triple: x86_64-apple-darwin
+          - name: macOS
+            triple: x86_64-apple-darwin
           - name: FreeBSD
             triple: x86_64-unknown-freebsd
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,3 +16,6 @@ targets = ["x86_64-unknown-linux-gnu"]
 
 [target.'cfg(target_os = "freebsd")'.dependencies]
 libc = "0.2.107"
+
+[target.'cfg(target_os = "macos")'.dependencies]
+libc = "0.2.107"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,8 +14,5 @@ targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
 
-[target.'cfg(target_os = "freebsd")'.dependencies]
-libc = "0.2.107"
-
-[target.'cfg(target_os = "macos")'.dependencies]
+[target.'cfg(any(target_os = "macos", target_os = "freebsd"))'.dependencies]
 libc = "0.2.107"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,5 @@
 //! Minimum supported Rust version: 1.28
 
-extern crate libc;
-
 use std::num::NonZeroUsize;
 
 #[cfg_attr(target_os = "linux", path = "linux.rs")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,7 @@
 //! Minimum supported Rust version: 1.28
 
+extern crate libc;
+
 use std::num::NonZeroUsize;
 
 #[cfg_attr(target_os = "linux", path = "linux.rs")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,6 +4,7 @@ use std::num::NonZeroUsize;
 
 #[cfg_attr(target_os = "linux", path = "linux.rs")]
 #[cfg_attr(target_os = "freebsd", path = "freebsd.rs")]
+#[cfg_attr(target_os = "macos", path = "macos.rs")]
 mod imp;
 
 /// Obtain the number of threads currently part of the active process. Returns `None` if the number

--- a/src/macos.rs
+++ b/src/macos.rs
@@ -7,6 +7,9 @@ const PROC_TASKINFO_SIZE: usize = mem::size_of::<libc::proc_taskinfo>();
 
 pub(crate) fn num_threads() -> Option<NonZeroUsize> {
     let buffer = unsafe { libc::malloc(PROC_TASKINFO_SIZE) };
+    if buffer.is_null() {
+        return None;
+    }
 
     let result = unsafe {
         libc::proc_pidinfo(

--- a/src/macos.rs
+++ b/src/macos.rs
@@ -3,22 +3,28 @@ extern crate libc;
 use std::mem;
 use std::num::NonZeroUsize;
 
+const PROC_TASKINFO_SIZE: usize = mem::size_of::<libc::proc_taskinfo>();
+
 pub(crate) fn num_threads() -> Option<NonZeroUsize> {
-    unsafe {
-        let size = mem::size_of::<libc::proc_taskinfo>();
-        let buffer = libc::malloc(size);
+    let buffer = unsafe { libc::malloc(PROC_TASKINFO_SIZE) };
 
-        let c_size = size as libc::c_int;
-        let result = libc::proc_pidinfo(libc::getpid(), libc::PROC_PIDTASKINFO, 0, buffer, c_size);
-        if result != c_size {
-            return None;
-        }
-
-        let pti = buffer as *mut libc::proc_taskinfo;
-        // Safety: `malloc`ed memory is aligned for repr(C) structs, so dereference is safe.
-        let num_threads = NonZeroUsize::new(pti.as_ref()?.pti_threadnum as usize);
-
-        libc::free(pti as *mut libc::c_void);
-        num_threads
+    let result = unsafe {
+        libc::proc_pidinfo(
+            libc::getpid(),
+            libc::PROC_PIDTASKINFO,
+            0,
+            buffer,
+            PROC_TASKINFO_SIZE as libc::c_int,
+        )
+    };
+    if result != PROC_TASKINFO_SIZE as libc::c_int {
+        return None;
     }
+
+    let pti = buffer as *mut libc::proc_taskinfo;
+    // Safety: `malloc`ed memory is aligned for repr(C) structs, so dereference is safe.
+    let num_threads = NonZeroUsize::new(unsafe { pti.as_ref() }?.pti_threadnum as usize);
+
+    unsafe { libc::free(pti as *mut libc::c_void) };
+    num_threads
 }

--- a/src/macos.rs
+++ b/src/macos.rs
@@ -1,0 +1,24 @@
+extern crate libc;
+
+use std::mem;
+use std::num::NonZeroUsize;
+
+pub(crate) fn num_threads() -> Option<NonZeroUsize> {
+    unsafe {
+        let size = mem::size_of::<libc::proc_taskinfo>();
+        let buffer = libc::malloc(size);
+
+        let c_size = size as libc::c_int;
+        let result = libc::proc_pidinfo(libc::getpid(), libc::PROC_PIDTASKINFO, 0, buffer, c_size);
+        if result != c_size {
+            return None;
+        }
+
+        let pti = buffer as *mut libc::proc_taskinfo;
+        // Safety: `malloc`ed memory is aligned for repr(C) structs, so dereference is safe.
+        let num_threads = NonZeroUsize::new(pti.as_ref()?.pti_threadnum as usize);
+
+        libc::free(pti as *mut libc::c_void);
+        num_threads
+    }
+}


### PR DESCRIPTION
Trying to make it work on macos so that the `time` crate can return local_offset.

However I'm not sure whether the `proc_pidinfo` call is thread-safe because it's an apple internal api. Looks like it copies task info struct to given buffer, so I assume the buffer is properly initialized.