### PR TITLE
Avoid heap allocation on MacOS

### DIFF
--- a/src/macos.rs
+++ b/src/macos.rs
@@ -6,28 +6,21 @@ use std::num::NonZeroUsize;
 const PROC_TASKINFO_SIZE: usize = mem::size_of::<libc::proc_taskinfo>();
 
 pub(crate) fn num_threads() -> Option<NonZeroUsize> {
-    let buffer = unsafe { libc::malloc(PROC_TASKINFO_SIZE) };
-    if buffer.is_null() {
-        return None;
-    }
+    let mut pti: libc::proc_taskinfo = unsafe { mem::zeroed() };
 
     let result = unsafe {
         libc::proc_pidinfo(
             libc::getpid(),
             libc::PROC_PIDTASKINFO,
             0,
-            buffer,
+            &mut pti as *mut libc::proc_taskinfo as *mut libc::c_void,
             PROC_TASKINFO_SIZE as libc::c_int,
         )
     };
-    if result != PROC_TASKINFO_SIZE as libc::c_int {
-        return None;
+
+    if result == PROC_TASKINFO_SIZE as libc::c_int {
+        return NonZeroUsize::new(pti.pti_threadnum as usize);
     }
 
-    let pti = buffer as *mut libc::proc_taskinfo;
-    // Safety: `malloc`ed memory is aligned for repr(C) structs, so dereference is safe.
-    let num_threads = NonZeroUsize::new(unsafe { pti.as_ref() }?.pti_threadnum as usize);
-
-    unsafe { libc::free(pti as *mut libc::c_void) };
-    num_threads
+    None
 }


### PR DESCRIPTION
This forgoes allocation in favour of stack allocation - and also avoids a leak if the call to `proc_pidinfo` fails for some reason.

I don't have a Mac to test on so I don't know if it even compiles, but this certainly seems a better approach than heap allocating.