### PR TITLE
Rewrite MacOS implementation to use public APIs only

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Unreleased
+
+- Modified MacOS implementation to be friendly towards Apple app store review guidelines.
+
 # 0.1.2
 
 - Add support for MacOS

--- a/src/macos.rs
+++ b/src/macos.rs
@@ -1,26 +1,45 @@
 extern crate libc;
 
-use std::mem;
 use std::num::NonZeroUsize;
 
-const PROC_TASKINFO_SIZE: usize = mem::size_of::<libc::proc_taskinfo>();
+use self::libc::{kern_return_t, mach_msg_type_number_t, mach_port_t, thread_t};
+
+// This constant is from
+// /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/
+// usr/include/mach/machine/thread_state.h.
+//
+// It has not been updated since Apple devices started to support 64-bit ARM (iOS), so it
+// should be very stable.
+const THREAD_STATE_MAX: i32 = 1296;
+#[allow(non_camel_case_types)]
+// https://github.com/apple/darwin-xnu/blob/a1babec6b135d1f35b2590a1990af3c5c5393479/osfmk/mach/mach_types.defs#L155
+type task_inspect_t = mach_port_t;
+#[allow(non_camel_case_types)]
+// https://github.com/apple/darwin-xnu/blob/a1babec6b135d1f35b2590a1990af3c5c5393479/osfmk/mach/mach_types.defs#L238
+type thread_array_t = [thread_t; THREAD_STATE_MAX as usize];
+
+extern "C" {
+    // https://developer.apple.com/documentation/kernel/1537751-task_threads/
+    fn task_threads(
+        target_task: task_inspect_t,
+        act_list: *mut thread_array_t,
+        act_listCnt: *mut mach_msg_type_number_t,
+    ) -> kern_return_t;
+}
 
 pub(crate) fn num_threads() -> Option<NonZeroUsize> {
-    let mut pti: libc::proc_taskinfo = unsafe { mem::zeroed() };
+    // http://web.mit.edu/darwin/src/modules/xnu/osfmk/man/task_threads.html
+    let mut thread_state = [0u32; THREAD_STATE_MAX as usize];
+    let mut thread_count = 0;
 
-    let result = unsafe {
-        libc::proc_pidinfo(
-            libc::getpid(),
-            libc::PROC_PIDTASKINFO,
-            0,
-            &mut pti as *mut libc::proc_taskinfo as *mut libc::c_void,
-            PROC_TASKINFO_SIZE as libc::c_int,
-        )
-    };
+    // Safety: `mach_task_self` always returns a valid value, `thread_state` is large enough, and
+    // both it and `thread_count` are writable.
+    let result =
+        unsafe { task_threads(libc::mach_task_self(), &mut thread_state, &mut thread_count) };
 
-    if result == PROC_TASKINFO_SIZE as libc::c_int {
-        return NonZeroUsize::new(pti.pti_threadnum as usize);
+    if result == libc::KERN_SUCCESS {
+        NonZeroUsize::new(thread_count as usize)
+    } else {
+        None
     }
-
-    None
 }


### PR DESCRIPTION
Hello,

While updating crates for a project, I noticed that `time` >= 0.3.6 began to depend on this crate. After reviewing what it was, I found that the APIs currently used on `main` are problematic for any consumers who ship Rust code in apps distributed via Apple's stores.

`proc_pidinfo` is what Apple considers a "private API" (see the top of [its header location](https://opensource.apple.com/source/xnu/xnu-2422.1.72/libsyscall/wrappers/libproc/libproc.h.auto.html)), which means that if they detect a library linking to or referencing the symbols during review, they will reject the upload. The `sysinfo` crate [had a similar issue](https://github.com/GuillaumeGomez/sysinfo/pull/424) before.

This PR replaces the use of `proc_pidinfo` with public Mach APIs instead. [`mach_task_self`](https://developer.apple.com/library/archive/documentation/Darwin/Conceptual/KernelProgramming/Mach/Mach.html) and `task_threads` are both referenced in Apple's public facing documentation and kernel headers.