### PR TITLE
Update Rust version to build libc on Apple Silicon

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -58,7 +58,7 @@ jobs:
         uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: 1.28
+          toolchain: 1.54.0
           target: ${{ matrix.target.triple }}
           override: true
 


### PR DESCRIPTION
Tries to address #19 

The current version of Rust being used to build is 1.28, which is nearly 5 years old.

This leads to `libc` not compiling on macOS (Apple Silicon) in the tests.

This change updates Rust to 1.76.0, the latest version as of the writing of this ticket.

