### PR TITLE
Cleanup Apple implementation

### DIFF
--- a/src/apple.rs
+++ b/src/apple.rs
@@ -3,7 +3,8 @@ extern crate libc;
 use std::num::NonZeroUsize;
 
 use self::libc::{
-    kern_return_t, mach_port_t, natural_t, task_threads, thread_act_array_t, vm_size_t,
+    kern_return_t, mach_port_t, natural_t, task_threads, thread_act_array_t, vm_address_t,
+    vm_deallocate,
 };
 
 #[allow(non_camel_case_types)]
@@ -11,13 +12,6 @@ use self::libc::{
 type mach_port_name_t = natural_t;
 
 extern "C" {
-    // https://developer.apple.com/documentation/kernel/1402285-mach_vm_deallocate
-    fn mach_vm_deallocate(
-        target_task: mach_port_t,
-        address: *mut u32,
-        size: vm_size_t,
-    ) -> kern_return_t;
-
     // https://developer.apple.com/documentation/kernel/1578777-mach_port_deallocate
     fn mach_port_deallocate(task: mach_port_t, name: mach_port_name_t) -> kern_return_t;
 }
@@ -41,11 +35,11 @@ pub(crate) fn num_threads() -> Option<NonZeroUsize> {
                 mach_port_deallocate(task, *(thread_list.offset(thread as isize)) as u32);
             }
         }
-        // Deallocate the thread list
+        // Deallocate the thread list's memory, now that everything inside of it has been released.
         unsafe {
-            mach_vm_deallocate(
+            vm_deallocate(
                 task,
-                thread_list,
+                thread_list as vm_address_t,
                 std::mem::size_of::<mach_port_t>() * thread_count as usize,
             );
         }

--- a/src/apple.rs
+++ b/src/apple.rs
@@ -1,5 +1,6 @@
 extern crate libc;
 
+use std::convert::TryInto;
 use std::num::NonZeroUsize;
 
 use self::libc::{
@@ -29,22 +30,28 @@ pub(crate) fn num_threads() -> Option<NonZeroUsize> {
     let result = unsafe { task_threads(task, &mut thread_list, &mut thread_count) };
 
     if result == libc::KERN_SUCCESS {
+        // It is impossible for the early return below to be taken and cause a memory leak:
+        // - `u32` -> `usize` is infallible on any Apple target because the minimum pointer size
+        //   anywhere is 32-bit,
+        // - It is not possible for a process to have 0 threads and be alive, so this code running
+        //   proves at least one thread exists
+        let thread_count = thread_count.try_into().ok().and_then(NonZeroUsize::new)?;
+
         // Deallocate the mach port rights for the threads
-        for thread in 0..thread_count {
-            unsafe {
-                mach_port_deallocate(task, *(thread_list.offset(thread as isize)) as u32);
-            }
+        for thread in 0..thread_count.get() {
+            unsafe { mach_port_deallocate(task, *(thread_list.add(thread))) };
         }
         // Deallocate the thread list's memory, now that everything inside of it has been released.
         unsafe {
             vm_deallocate(
                 task,
+                // XXX: Use `expose_provenance` when MSRV is high enough.
                 thread_list as vm_address_t,
-                std::mem::size_of::<mach_port_t>() * thread_count as usize,
+                thread_count.get() * std::mem::size_of::<mach_port_t>(),
             );
         }
 
-        NonZeroUsize::new(thread_count as usize)
+        Some(thread_count)
     } else {
         None
     }

--- a/src/apple.rs
+++ b/src/apple.rs
@@ -15,6 +15,10 @@ type mach_port_name_t = natural_t;
 extern "C" {
     // https://developer.apple.com/documentation/kernel/1578777-mach_port_deallocate
     fn mach_port_deallocate(task: mach_port_t, name: mach_port_name_t) -> kern_return_t;
+    // `libc::mach_task_self` (deprecated) wraps this and its SDK header states that it
+    // is concurrency safe (mach/mach_init.h):
+    // `extern __swift_nonisolated_unsafe mach_port_t mach_task_self_;`
+    static mut mach_task_self_: mach_port_t;
 }
 
 pub(crate) fn num_threads() -> Option<NonZeroUsize> {
@@ -23,11 +27,10 @@ pub(crate) fn num_threads() -> Option<NonZeroUsize> {
     let mut thread_count = 0;
 
     // Safety:
-    //  - `mach_task_self` always returns a valid value,
+    //  - `mach_task_self` is always valid to access,
     //  - `thread_list` is a pointer that will point to kernel allocated memory that needs to be
     //    deallocated if the call succeeds
-    let task = unsafe { libc::mach_task_self() };
-    let result = unsafe { task_threads(task, &mut thread_list, &mut thread_count) };
+    let result = unsafe { task_threads(mach_task_self_, &mut thread_list, &mut thread_count) };
 
     if result == libc::KERN_SUCCESS {
         // It is impossible for the early return below to be taken and cause a memory leak:
@@ -39,12 +42,20 @@ pub(crate) fn num_threads() -> Option<NonZeroUsize> {
 
         // Deallocate the mach port rights for the threads
         for thread in 0..thread_count.get() {
-            unsafe { mach_port_deallocate(task, *(thread_list.add(thread))) };
+            // Safety:
+            // - `mach_task_self` is always valid to access,
+            // - `thread_list` is valid to read and `thread` is always within the array's bounds
+            unsafe { mach_port_deallocate(mach_task_self_, *(thread_list.add(thread))) };
         }
         // Deallocate the thread list's memory, now that everything inside of it has been released.
+        // Safety:
+        // `mach_task_self` is always valid to access,
+        // `thread_list` was originally allocated as kernel memory and has not been modified.
+        // `size` is the same number of elements returned by the original call and the same number
+        // deallocated above.
         unsafe {
             vm_deallocate(
-                task,
+                mach_task_self_,
                 // XXX: Use `expose_provenance` when MSRV is high enough.
                 thread_list as vm_address_t,
                 thread_count.get() * std::mem::size_of::<mach_port_t>(),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,7 +4,7 @@ use std::num::NonZeroUsize;
 
 #[cfg_attr(any(target_os = "linux", target_os = "android"), path = "linux.rs")]
 #[cfg_attr(target_os = "freebsd", path = "freebsd.rs")]
-#[cfg_attr(any(target_os = "macos", target_os = "ios"), path = "apple.rs")]
+#[cfg_attr(target_vendor = "apple", path = "apple.rs")]
 #[cfg_attr(target_os = "aix", path = "aix.rs")]
 mod imp;
 


### PR DESCRIPTION
This PR resolves the confusing type size implications pointed out in a recent report and additionally cleans up the other type casing done inside the Apple implementation to be cleaner. It also handles a trivial `libc` deprecation I noticed opening up a fresh clone of the repository.

Commit-by-commit review is recommended.

Closes #22